### PR TITLE
Testing against reference implementation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *Builder) void {
     lib.setBuildMode(mode);
 
     var tests = b.addTest("test/test.zig");
+    tests.addPackagePath("wyhash", "src/main.zig");
     tests.setBuildMode(mode);
 
     const test_step = b.step("test", "Run library tests");

--- a/build.zig
+++ b/build.zig
@@ -7,6 +7,8 @@ pub fn build(b: *Builder) void {
 
     var tests = b.addTest("test/test.zig");
     tests.addPackagePath("wyhash", "src/main.zig");
+    tests.addCSourceFile("reference/wyhash.c", [][]const u8{});
+    tests.linkSystemLibrary("c");
     tests.setBuildMode(mode);
 
     const test_step = b.step("test", "Run library tests");

--- a/reference/wyhash.c
+++ b/reference/wyhash.c
@@ -1,0 +1,86 @@
+/*	Author: Wang Yi <godspeed_china@yeah.net>	*/
+#ifndef wyhash_version_1
+#define wyhash_version_1
+#include	<string.h>
+#include	<math.h>
+#if defined(_MSC_VER) && defined(_M_X64)
+	#include <intrin.h>
+	#pragma	intrinsic(_umul128)
+#endif
+const	unsigned long long	_wyp0=0xa0761d6478bd642full,	_wyp1=0xe7037ed1a0b428dbull,	_wyp2=0x8ebc6af09c88c6e3ull;
+const	unsigned long long	_wyp3=0x589965cc75374cc3ull,	_wyp4=0x1d8e4e27c47d124full,	_wyp5=0xeb44accab455d165ull;
+static	inline	unsigned long long	_wymum(unsigned long long	A,	unsigned long long	B){
+#ifdef __SIZEOF_INT128__
+	__uint128_t	r=A;	r*=B;	return	(r>>64)^r;
+#elif	defined(_MSC_VER) && defined(_M_X64)
+	A=_umul128(A, B, &B);	return	A^B;
+#else
+	unsigned long long	ha=A>>32,	hb=B>>32,	la=(unsigned int)A,	lb=(unsigned int)B,	hi, lo;
+	unsigned long long	rh=ha*hb,	rm0=ha*lb,	rm1=hb*la,	rl=la*lb,	t=rl+(rm0<<32),	c=t<rl;
+	lo=t+(rm1<<32);	c+=lo<t;	hi=rh+(rm0>>32)+(rm1>>32)+c;
+	return hi^lo;
+#endif
+}
+static	inline	unsigned long long	_wyr08(const	unsigned char	*p){	unsigned char v;	memcpy(&v,	p,	1);	return	v;	}
+static	inline	unsigned long long	_wyr16(const	unsigned char	*p){	unsigned short v;	memcpy(&v,	p,	2);	return	v;	}
+static	inline	unsigned long long	_wyr32(const	unsigned char	*p){	unsigned int v;	memcpy(&v,	p,	4);	return	v;	}
+static	inline	unsigned long long	_wyr64(const	unsigned char	*p){	unsigned long long v;	memcpy(&v,	p,	8);	return	v;	}
+static	inline	unsigned long long	__wyr64(const	unsigned char	*p){	return	(_wyr32(p)<<32)|_wyr32(p+4);	}
+unsigned long long	wyhash(const void* key,	unsigned long long	len, unsigned long long	seed){
+	const	unsigned char	*p=(const	unsigned char*)key;	unsigned long long i;
+	for(i=0;	i+32<=len;	i+=32,	p+=32)	seed=_wymum(seed^_wyp0,	_wymum(_wyr64(p)^_wyp1,_wyr64(p+8)^_wyp2)^_wymum(_wyr64(p+16)^_wyp3,_wyr64(p+24)^_wyp4));
+	seed^=_wyp0;
+	switch(len&31){
+	case	1:	seed=_wymum(seed,_wyr08(p)^_wyp1);	break;
+	case	2:	seed=_wymum(seed,_wyr16(p)^_wyp1);	break;
+	case	3:	seed=_wymum(seed,((_wyr16(p)<<8)|_wyr08(p+2))^_wyp1);	break;
+	case	4:	seed=_wymum(seed,_wyr32(p)^_wyp1);	break;
+	case	5:	seed=_wymum(seed,((_wyr32(p)<<8)|_wyr08(p+4))^_wyp1);	break;
+	case	6:	seed=_wymum(seed,((_wyr32(p)<<16)|_wyr16(p+4))^_wyp1);	break;
+	case	7:	seed=_wymum(seed,((_wyr32(p)<<24)|(_wyr16(p+4)<<8)|_wyr08(p+6))^_wyp1);	break;
+	case	8:	seed=_wymum(seed,__wyr64(p)^_wyp1);	break;
+	case	9:	seed=_wymum(__wyr64(p)^seed,_wyr08(p+8)^_wyp2);	break;
+	case	10:	seed=_wymum(__wyr64(p)^seed,_wyr16(p+8)^_wyp2);	break;
+	case	11:	seed=_wymum(__wyr64(p)^seed,((_wyr16(p+8)<<8)|_wyr08(p+8+2))^_wyp2);	break;
+	case	12:	seed=_wymum(__wyr64(p)^seed,_wyr32(p+8)^_wyp2);	break;
+	case	13:	seed=_wymum(__wyr64(p)^seed,((_wyr32(p+8)<<8)|_wyr08(p+8+4))^_wyp2);	break;
+	case	14:	seed=_wymum(__wyr64(p)^seed,((_wyr32(p+8)<<16)|_wyr16(p+8+4))^_wyp2);	break;
+	case	15:	seed=_wymum(__wyr64(p)^seed,((_wyr32(p+8)<<24)|(_wyr16(p+8+4)<<8)|_wyr08(p+8+6))^_wyp2);	break;
+	case	16:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2);	break;
+	case	17:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr08(p+16)^_wyp3);	break;
+	case	18:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr16(p+16)^_wyp3);	break;
+	case	19:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr16(p+16)<<8)|_wyr08(p+16+2))^_wyp3);	break;
+	case	20:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,_wyr32(p+16)^_wyp3);	break;
+	case	21:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<8)|_wyr08(p+16+4))^_wyp3);	break;
+	case	22:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<16)|_wyr16(p+16+4))^_wyp3);	break;
+	case	23:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,((_wyr32(p+16)<<24)|(_wyr16(p+16+4)<<8)|_wyr08(p+16+6))^_wyp3);	break;
+	case	24:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(seed,__wyr64(p+16)^_wyp3);	break;
+	case	25:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr08(p+24)^_wyp4);	break;
+	case	26:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr16(p+24)^_wyp4);	break;
+	case	27:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr16(p+24)<<8)|_wyr08(p+24+2))^_wyp4);	break;
+	case	28:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,_wyr32(p+24)^_wyp4);	break;
+	case	29:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<8)|_wyr08(p+24+4))^_wyp4);	break;
+	case	30:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<16)|_wyr16(p+24+4))^_wyp4);	break;
+	case	31:	seed=_wymum(__wyr64(p)^seed,__wyr64(p+8)^_wyp2)^_wymum(__wyr64(p+16)^seed,((_wyr32(p+24)<<24)|(_wyr16(p+24+4)<<8)|_wyr08(p+24+6))^_wyp4);	break;
+	}
+	return	_wymum(seed,	len^_wyp5);
+}
+static	inline	unsigned long long	wyhash64(unsigned long long	A, unsigned long long	B){	return	_wymum(_wymum(A^_wyp0,	B^_wyp1),	_wyp2);	}
+static	inline	double	wy2u01(unsigned long long	r){	const	double	_wynorm=1.0/(1ull<<52);	return	(r&0x000fffffffffffffull)*_wynorm; }
+static	inline	float	wy2gau(unsigned long long	r){	const	float	_wynorm1=1.0f/(1ull<<20);	return	((r&0x1fffff)+((r>>21)&0x1fffff)+(r>>43))*_wynorm1-3.0f;	}
+static	unsigned long long	_wyrand_seed=0;
+#define	WYRAND_MAX	0xffffffffffffffffull
+static	inline	void	wysrand(unsigned long long	seed){	_wyrand_seed=seed;	}
+static	inline	unsigned long long	wyrand(void){
+	unsigned long long s;
+	#if defined(_OPENMP)
+	#pragma omp atomic capture
+	#endif
+	{
+		_wyrand_seed += _wyp0;
+		s = _wyrand_seed;
+	}
+	return	_wymum(s^_wyp1,s);
+}
+#endif
+

--- a/test/test.zig
+++ b/test/test.zig
@@ -1,9 +1,19 @@
 const std = @import("std");
 const testing = std.testing;
 
-const wy = @import("src/main.zig");
+const wy = @import("wyhash");
 
-// Tests, would put here if I'd know how to include a library
-test "Byte order" {
 
 }
+
+test "test vectors" {
+    testing.expectEqual(wy.hash("", 0), 0xf961f936e29c9345);
+    testing.expectEqual(wy.hash("a", 1), 0x6dc395f88b363baa);
+    testing.expectEqual(wy.hash("abc", 2), 0x3bc9d7844798ddaa);
+    testing.expectEqual(wy.hash("message digest", 3), 0xb31238dc2c500cd3);
+    testing.expectEqual(wy.hash("abcdefghijklmnopqrstuvwxyz", 4), 0xea0f542c58cddfe4);
+    testing.expectEqual(wy.hash("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 5), 0x1799aca591fe73b4);
+    testing.expectEqual(wy.hash("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 6), 0x7f0d02f53d64c1f9);
+}
+
+test "Byte order" {}

--- a/test/test.zig
+++ b/test/test.zig
@@ -3,7 +3,17 @@ const testing = std.testing;
 
 const wy = @import("wyhash");
 
+// Imported from the C object file.
+extern fn wyhash(key: *const c_void, len: u64, seed: u64) u64;
 
+test "reference test vectors" {
+    testing.expectEqual(wyhash(c"", 0, 0), 0xf961f936e29c9345);
+    testing.expectEqual(wyhash(c"a", 1, 1), 0x6dc395f88b363baa);
+    testing.expectEqual(wyhash(c"abc", 3, 2), 0x3bc9d7844798ddaa);
+    testing.expectEqual(wyhash(c"message digest", 14, 3), 0xb31238dc2c500cd3);
+    testing.expectEqual(wyhash(c"abcdefghijklmnopqrstuvwxyz", 26, 4), 0xea0f542c58cddfe4);
+    testing.expectEqual(wyhash(c"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62, 5), 0x1799aca591fe73b4);
+    testing.expectEqual(wyhash(c"12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80, 6), 0x7f0d02f53d64c1f9);
 }
 
 test "test vectors" {


### PR DESCRIPTION
This is how you could organize your tests.

Ideally you would use [@cImport](https://ziglang.org/documentation/master/#cImport) to use `wyhash.h`, but I think there are currently two problems with that:
- the reference wyhash implementation uses function overloading, so it is not C but C++ (see the `wyrand` functions)
- `zig translate-c` seems to not be able to give correct output for this header

Therefore I had to make a slightly modified version of their source and compile it into an object file. I just removed one overload of `wyrand` and removed the `static` specifier on `hash` to make it link.

Then it can be tested with `zig build test`.

Feel free to accept this PR or use it as an example.